### PR TITLE
consertando O link para o detalhe da inscrição na página de detalhe de sele;'ao

### DIFF
--- a/aplicacoes/gpa-mae/src/main/webapp/WEB-INF/views/servidor/detalhesSelecaoServidor.jsp
+++ b/aplicacoes/gpa-mae/src/main/webapp/WEB-INF/views/servidor/detalhesSelecaoServidor.jsp
@@ -102,7 +102,7 @@
 							<c:forEach var="inscricao" items="${inscricoes }">
 								<tr>
 									<td><a id="detalhes"
-										href="<c:url value="/servidor/detalhes/inscricao/${inscricao.aluno.id}">  
+										href="<c:url value="/servidor/detalhes/inscricao/${inscricao.id}">  
 									</c:url>">
 											${inscricao.aluno.pessoa.nome }</a></td>
 									<td>${inscricao.aluno.matricula }</td>


### PR DESCRIPTION
consertando O link para o detalhe da inscrição na página de detalhe de uma seleção que estava incorreto.O link agora passa o id da inscrição e não do aluno.